### PR TITLE
Fixes calculate num of cpu threads for HappyPack

### DIFF
--- a/scripts/webpack.general.config.js
+++ b/scripts/webpack.general.config.js
@@ -105,7 +105,7 @@ module.exports = (options = {}) => ({
 	plugins: [
 		new HappyPack({
 			id: "ts",
-			threads: os.cpus().length - 1,
+			threads: Math.max(os.cpus().length - 1, 1),
 			loaders: [{
 				path: "ts-loader",
 				query: {


### PR DESCRIPTION
HappyPack requires a positive integer for threads. And when the number of cpu is 1, it is calculated 1 - 1 = 0. Now a minimal value will be 1.