### PR TITLE
Remove unused markup from password page

### DIFF
--- a/packages/app/browser/src/app.html
+++ b/packages/app/browser/src/app.html
@@ -19,21 +19,6 @@
 					<label class="mdc-floating-label" for="password">Password</label>
 					<div class="mdc-line-ripple"></div>
 				</div>
-				<div class="mdc-text-field-helper-line">
-					<div class="mdc-text-field-helper-text">helper text</div>
-				</div>
-				<div class="mdc-form-field">
-					<div class="mdc-checkbox">
-						<input type="checkbox" class="mdc-checkbox__native-control" id="remember" />
-						<div class="mdc-checkbox__background">
-							<svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-								<path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-							</svg>
-							<div class="mdc-checkbox__mixedmark"></div>
-						</div>
-					</div>
-					<label for="remember">Remember Me</label>
-				</div>
 				<button id="submit" class="mdc-button mdc-button--unelevated">
 					<span class="mdc-button__label">Enter IDE</span>
 				</button>


### PR DESCRIPTION
![screen shot 2019-03-06 at 1 56 20 pm](https://user-images.githubusercontent.com/16672952/53910313-2758c580-4019-11e9-9104-1d6bb07ffcd4.png)

Currently this checkbox does nothing. Neither does "helper text" provide any useful context at this time. We can remove them for now.