### PR TITLE
update example docker command port bind options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Try it out:
 ```bash
-docker run -p localhost:8443:8443 -v "${PWD}:/root/project" codercom/code-server code-server --allow-http --no-auth
+docker run -p 127.0.0.1:8443:8443 -v "${PWD}:/root/project" codercom/code-server code-server --allow-http --no-auth
 ```
 
 - Code on your Chromebook, tablet, and laptop with a consistent dev environment.


### PR DESCRIPTION
The existing command errors out with 

```
docker: invalid publish opts format (should be name=value but got 'localhost:8443:8443').
```

it needs to explicitly use an IP and not a hostname. 