### PR TITLE
[README] Remove --allow-http from docker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Try it out:
 ```bash
-docker run -p 127.0.0.1:8443:8443 -v "${PWD}:/root/project" codercom/code-server code-server --allow-http --no-auth
+docker run -p 127.0.0.1:8443:8443 -v "${PWD}:/root/project" codercom/code-server code-server --no-auth
 ```
 
 - Code on your Chromebook, tablet, and laptop with a consistent dev environment.


### PR DESCRIPTION
Chrome disables clipboard API when connecting to HTTP sites.
As a consequence, if a user connects to `code-server` with HTTP, they cannot cut or copy texts.