### PR TITLE
Use a timing-safe equality check for passwords

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
 		"node-netstat": "^1.6.0",
 		"pem": "^1.14.1",
 		"promise.prototype.finally": "^3.1.0",
+		"safe-compare": "^1.1.4",
 		"ws": "^6.1.2",
 		"xhr2": "^0.1.4"
 	},
@@ -28,6 +29,7 @@
 		"@types/mime-types": "^2.1.0",
 		"@types/opn": "^5.1.0",
 		"@types/pem": "^1.9.4",
+		"@types/safe-compare": "^1.1.0",
 		"@types/ws": "^6.0.1",
 		"fs-extra": "^7.0.1",
 		"nexe": "^2.0.0-rc.34",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -16,6 +16,7 @@ import * as path from "path";
 import * as pem from "pem";
 import * as util from "util";
 import * as ws from "ws";
+import safeCompare = require("safe-compare");
 import { TunnelCloseCode } from "@coder/tunnel/src/common";
 import { handle as handleTunnel } from "@coder/tunnel/src/server";
 import { createPortScanner } from "./portScanner";
@@ -67,7 +68,7 @@ export const createApp = async (options: CreateAppOptions): Promise<{
 
 			// Try/catch placed here just in case
 			const cookies = parseCookies(req);
-			if (cookies.password && cookies.password === options.password) {
+			if (cookies.password && safeCompare(cookies.password, options.password)) {
 				return true;
 			}
 		} catch (ex) {

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -148,6 +148,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/safe-compare@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/safe-compare/-/safe-compare-1.1.0.tgz#47ed9b9ca51a3a791b431cd59b28f47fa9bf1224"
+  integrity sha512-1ri+LJhh0gRxIa37IpGytdaW7yDEHeJniBSMD1BmitS07R1j63brcYCzry+l0WJvGdEKQNQ7DYXO2epgborWPw==
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -3154,6 +3159,13 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-compare@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/safe-compare/-/safe-compare-1.1.4.tgz#5e0128538a82820e2e9250cd78e45da6786ba593"
+  integrity sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==
+  dependencies:
+    buffer-alloc "^1.2.0"
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
As the current implementation of password checking uses `===` to check equality, it is susceptible to timing attacks - see [this article](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/) for more information.

This PR uses [`safe-compare`](https://github.com/Bruce17/safe-compare) to compare passwords without the possibility of a timing attack.

(Note that I could not test this change, as I was unable to successfully build the project. Please confirm that this change does not break anything before merging it!)

