### PR TITLE
Add support for Kubernetes 

### DIFF
--- a/deployment/aws/deployment.yaml
+++ b/deployment/aws/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+ name: code-server
+ namespace: code-server
+spec:
+ ports:
+ - port: 8443
+   name: https
+   protocol: TCP
+ selector:
+   app: code-server
+ type: ClusterIP
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gp2
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+  fsType: ext4 
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: code-store
+  namespace: code-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 60Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: code-server
+  name: code-server
+  namespace: code-server
+spec:
+  selector:
+    matchLabels:
+      app: code-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: code-server
+    spec:
+      containers:
+      - image: codercom/code-server
+        imagePullPolicy: Always
+        name: code-servery
+        ports:
+        - containerPort: 8443
+          name: https
+        volumeMounts:
+        - name: code-server-storage
+          mountPath: /go/src
+      volumes:
+      - name: code-server-storage
+        persistentVolumeClaim:
+          claimName: code-store
+      

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+ name: code-server
+ namespace: code-server
+spec:
+ ports:
+ - port: 8443
+   name: https
+   protocol: TCP
+ selector:
+   app: code-server
+ type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: code-server
+  name: code-server
+  namespace: code-server
+spec:
+  selector:
+    matchLabels:
+      app: code-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: code-server
+    spec:
+      containers:
+      - image: codercom/code-server
+        imagePullPolicy: Always
+        name: code-server
+        ports:
+        - containerPort: 8443
+          name: https


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

Fixes #60 by adding support for Kubernetes. This deploys code-server, Contour for ingress controller, and Cert Manager for Let's Encrypt certificates, with persistent storage with AWS EBS volumes. Also, I left the Dockerfile I used for golang development. If there's a public push of this somewhere it would be great to document how you can create base images with the right tooling up front. 

This is also somewhat opiononated in that it's using AWS EBS volumes, but can be adapted for many use cases. I wasn't sure how that might get organized within the repo. 

Signed-off-by: Steve Sloka <slokas@vmware.com>

### Is there an open issue you can link to?

#60 

// cc @jbeda
