### PR TITLE
open websocket on same path as page

### DIFF
--- a/packages/ide/src/fill/client.ts
+++ b/packages/ide/src/fill/client.ts
@@ -91,8 +91,9 @@ class WebsocketConnection implements ReadWriteConnection {
 	 */
 	private async openSocket(): Promise<WebSocket> {
 		this.dispose();
+		const wsProto = location.protocol === "https:" ? "wss" : "ws";
 		const socket = new WebSocket(
-			`${location.protocol === "https:" ? "wss" : "ws"}://${location.host}`,
+			`${wsProto}://${location.host}${location.pathname}`,
 		);
 		socket.binaryType = "arraybuffer";
 		this.activeSocket = socket;


### PR DESCRIPTION
This is the critical piece to let you serve code-server proxied under a
path.  Otherwise if you proxy e.g. `/editor/` thru to
`http://localhost:8000`, everything works fine except the websocket
connection is still opened to `/`