### PR TITLE
Adhere to XDG base directory spec for dataDir and logDir

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -12,7 +12,7 @@ import { requireModule, requireFork, forkModule } from "./vscode/bootstrapFork";
 import { SharedProcess, SharedProcessState } from "./vscode/sharedProcess";
 import { setup as setupNativeModules } from "./modules";
 import { fillFs } from "./fill";
-import { isCli, serveStatic, buildDir } from "./constants";
+import { isCli, serveStatic, buildDir, dataHome, cacheHome } from "./constants";
 import opn = require("opn");
 
 export class Entry extends Command {
@@ -49,7 +49,7 @@ export class Entry extends Command {
 		}
 
 		const { args, flags } = this.parse(Entry);
-		const dataDir = path.resolve(flags["data-dir"] || path.join(os.homedir(), ".code-server"));
+		const dataDir = path.resolve(flags["data-dir"] || path.join(dataHome, "code-server"));
 		const workingDir = path.resolve(args["workdir"]);
 
 		setupNativeModules(dataDir);
@@ -81,7 +81,11 @@ export class Entry extends Command {
 			fs.mkdirSync(dataDir);
 		}
 
-		const logDir = path.join(dataDir, "logs", new Date().toISOString().replace(/[-:.TZ]/g, ""));
+		if (!fs.existsSync(cacheHome)) {
+			fs.mkdirSync(cacheHome);
+		}
+
+		const logDir = path.join(cacheHome, "code-server/logs", new Date().toISOString().replace(/[-:.TZ]/g, ""));
 		process.env.VSCODE_LOGS = logDir;
 
 		const certPath = flags.cert ? path.resolve(flags.cert) : undefined;

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -1,5 +1,11 @@
 import * as path from "path";
+import * as os from "os";
 
 export const isCli = typeof process.env.CLI !== "undefined" && process.env.CLI !== "false";
 export const serveStatic = typeof process.env.SERVE_STATIC !== "undefined" && process.env.SERVE_STATIC !== "false";
 export const buildDir = process.env.BUILD_DIR ? path.resolve(process.env.BUILD_DIR) : "";
+const xdgResolve = (primary: string | undefined, fallback: string): string => {
+	return primary ? path.resolve(primary) : path.resolve(process.env.HOME || os.homedir(), fallback);
+};
+export const dataHome = xdgResolve(process.env.XDG_DATA_HOME, ".local/share");
+export const cacheHome = xdgResolve(process.env.XDG_CACHE_HOME, ".cache");


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
Data files (`dataDir`) and log files (`logDir`) were defaulting to a hidden dir (`.code-server/`) in the base of the user's home directory, based on their OS. This did not conform with the [XDG standards](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#basics), which help make these kinds of paths predictable and organized.

### Is there an open issue you can link to?
Fixes https://github.com/codercom/code-server/issues/15
