### PR TITLE
Added ENTRYPOINT to omit full command at launch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ RUN apt-get install -y locales &&
 # configured in /etc/default/locale so we need to set it manually.
 ENV LANG=en_US.UTF-8
 # Unfortunately `.` does not work with code-server.
-CMD code-server $PWD
+ENTRYPOINT ["code-server"]
+CMD ["$PWD"]


### PR DESCRIPTION
Having `code-server` at the ENTRYPOINT will free the CMD line, so launching that container will no longer require writing the binary name after image name and will not confuse people anymore.

