### PR TITLE
Add error message for incorrect password. Fix issue #55

### DIFF
--- a/packages/app/browser/src/app.html
+++ b/packages/app/browser/src/app.html
@@ -8,21 +8,20 @@
 
 <body>
 	<div class="login">
-		<div class="back">
-			<- Back </div>
-			<h4 class="title">code-server</h4>
-				<h2 class="subtitle">
-					Enter server password
-				</h2>
-				<div class="mdc-text-field">
-					<input type="password" id="password" class="mdc-text-field__input" required>
-					<label class="mdc-floating-label" for="password">Password</label>
-					<div class="mdc-line-ripple"></div>
-				</div>
-				<button id="submit" class="mdc-button mdc-button--unelevated">
-					<span class="mdc-button__label">Enter IDE</span>
-				</button>
+		<div class="back"> <- Back </div>
+		<h4 class="title">code-server</h4>
+		<h2 class="subtitle">
+			Enter server password
+		</h2>
+		<div class="mdc-text-field">
+			<input type="password" id="password" class="mdc-text-field__input" required>
+			<label class="mdc-floating-label" for="password">Password</label>
+			<div class="mdc-line-ripple"></div>
 		</div>
+		<button id="submit" class="mdc-button mdc-button--unelevated">
+			<span class="mdc-button__label">Enter IDE</span>
+		</button>
+		<div id="error-display"></div>
 	</div>
 </body>
 

--- a/packages/app/browser/src/app.scss
+++ b/packages/app/browser/src/app.scss
@@ -106,3 +106,16 @@ body {
 
     // transition: 500ms opacity ease;
 }
+
+#error-display {
+    box-sizing: border-box;
+    color: #bb2d0f;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.3px;
+    line-height: 12px;
+    padding: 8px;
+    padding-bottom: 0;
+    padding-top: 20px;
+    text-align: center;
+}

--- a/packages/app/browser/src/app.ts
+++ b/packages/app/browser/src/app.ts
@@ -28,3 +28,14 @@ submit.addEventListener("click", () => {
 	document.cookie = `password=${password.value}`;
 	location.reload();
 });
+
+/**
+ * Notify user on load of page if previous password was unsuccessful
+ */
+const reg = new RegExp(`password=(\\w+);?`);
+const matches = document.cookie.match(reg);
+const errorDisplay = document.getElementById("error-display") as HTMLDivElement;
+
+if (document.referrer === document.location.href && matches) {
+	errorDisplay.innerText = "Password is incorrect!";
+}


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

Issue:
On initial welcome/login screen of binary, no error message is displayed in the event of an incorrect password. (See https://github.com/codercom/code-server/issues/55)

Changes:
Adds simple logic and styling for error display. Currently is of identical styling/design to the `coder.com` login page.

Test Environment:
OS: Mac OS High Sierra (10.13.6)
Browser: Google Chrome 72.0.3626.109 (Official Build) (64-bit)
(Result: Pass! Compile was successful and everything functions as expected)

Caveats:
None that I can think of at the moment. (I mean, the error message is hard coded. But this page has only one input and the page only has one purpose and does exactly one thing. So I don't know that this is necessarily a bad thing)
