### PR TITLE
Combine apt-get in final docker image and remove cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ COPY --from=0 /src/packages/server/cli-linux-x64 /usr/local/bin/code-server
 EXPOSE 8443
 RUN apt-get update && apt-get install -y \
 	openssl \
-	net-tools
-RUN apt-get install -y locales && \
-	locale-gen en_US.UTF-8
+	net-tools \
+	locales && \
+	locale-gen en_US.UTF-8 && \
+	rm -rf /var/lib/apt/lists/*
 # We unfortunately cannot use update-locale because docker will not use the env variables
 # configured in /etc/default/locale so we need to set it manually.
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it

I had no problem but this reduces the amount of layers needed to download and removes the apt-get cache to reduce the image size

### Is there an open issue you can link to?

nop