### PR TITLE
Fix security links in cloud setup guides

### DIFF
--- a/doc/admin/install/aws.md
+++ b/doc/admin/install/aws.md
@@ -41,7 +41,7 @@ If you're just starting out, we recommend [installing code-server locally](../..
   ```
   chmod +x code-server-linux
   ```
-  > To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../security/ssl.md)
+  > To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../../security/ssl.md)
 - Finally, run
   ```
   sudo ./code-server-linux -p 80

--- a/doc/admin/install/digitalocean.md
+++ b/doc/admin/install/digitalocean.md
@@ -24,7 +24,7 @@ If you're just starting out, we recommend [installing code-server locally](../..
   ```
   chmod +x code-server-linux
   ```
-  > To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../security/ssl.md)
+  > To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../../security/ssl.md)
 - Finally start the code-server
   ```
   sudo ./code-server-linux -p 80

--- a/doc/admin/install/google_cloud.md
+++ b/doc/admin/install/google_cloud.md
@@ -32,7 +32,7 @@ wget https://github.com/codercom/code-server/releases/download/0.1.4/code-server
   ```
   chmod +x code-server-linux
   ```
-> To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../security/ssl.md)
+> To ensure the connection between you and your server is encrypted view our guide on [securing your setup](../../security/ssl.md)
 4. Start the code-server
 ```
 sudo ./code-server-linux -p 80


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

Security links were broken in the cloud setup guides.

### Is there an open issue you can link to?

No.
