### PR TITLE
Fix vscode-textmate dependency

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -86,6 +86,7 @@ const buildServerBinaryCopy = register("build:server:binary:copy", async (runner
 	const webOutputPath = path.join(pkgsPath, "web", "out");
 	const browserAppOutputPath = path.join(pkgsPath, "app", "browser", "out");
 	const nodePtyModule = path.join(pkgsPath, "protocol", "node_modules", "node-pty-prebuilt", "build", "Release", "pty.node");
+	const onigModule = path.join(pkgsPath, "..", "lib", "vscode", "node_modules", "oniguruma", "build", "Release", "onig_scanner.node");
 	const spdlogModule = path.join(pkgsPath, "protocol", "node_modules", "spdlog", "build", "Release", "spdlog.node");
 	let ripgrepPath = path.join(pkgsPath, "..", "lib", "vscode", "node_modules", "vscode-ripgrep", "bin", "rg");
 	if (isWin) {
@@ -94,6 +95,9 @@ const buildServerBinaryCopy = register("build:server:binary:copy", async (runner
 
 	if (!fs.existsSync(nodePtyModule)) {
 		throw new Error("Could not find pty.node. Ensure all packages have been installed");
+	}
+	if (!fs.existsSync(onigModule)) {
+		throw new Error("Could not find onig_scanner.node. Ensure all packages have been installed");
 	}
 	if (!fs.existsSync(spdlogModule)) {
 		throw new Error("Could not find spdlog.node. Ensure all packages have been installed");
@@ -129,6 +133,7 @@ const buildServerBinaryCopy = register("build:server:binary:copy", async (runner
 	cpDir(browserAppOutputPath, "unauth", browserAppOutputPath);
 	fse.mkdirpSync(path.join(cliBuildPath, "dependencies"));
 	fse.copySync(nodePtyModule, path.join(cliBuildPath, "dependencies", "pty.node"));
+	fse.copySync(onigModule, path.join(cliBuildPath, "dependencies", "onig_scanner.node"));
 	fse.copySync(spdlogModule, path.join(cliBuildPath, "dependencies", "spdlog.node"));
 	fse.copySync(ripgrepPath, path.join(cliBuildPath, "dependencies", "rg"));
 });

--- a/packages/server/src/modules.ts
+++ b/packages/server/src/modules.ts
@@ -39,15 +39,19 @@ export const setup = (dataDirectory: string): void => {
 	unpackModule("pty.node");
 	unpackModule("spdlog.node");
 	unpackModule("rg", true);
+	unpackModule("onig_scanner.node");
 	// const nodePtyUtils = require("../../protocol/node_modules/node-pty-prebuilt/lib/utils") as typeof import("../../protocol/node_modules/node-pty-prebuilt/src/utils");
 	// tslint:disable-next-line:no-any
 	// nodePtyUtils.loadNative = (modName: string): any => {
 	// 	return (typeof __non_webpack_require__ !== "undefined" ? __non_webpack_require__ : require)(path.join(dataDirectory, "dependencies", modName + ".node"));
 	// };
 	(<any>global).RIPGREP_LOCATION = path.join(dataDirectory, "dependencies", "rg");
+	// tslint:disable-next-line:no-any
 	(<any>global).NODEPTY_LOCATION = path.join(dataDirectory, "dependencies", "pty.node");
 	// tslint:disable-next-line:no-any
 	(<any>global).SPDLOG_LOCATION = path.join(dataDirectory, "dependencies", "spdlog.node");
+	// tslint:disable-next-line:no-any
+	(<any>global).ONIG_LOCATION = path.join(dataDirectory, "dependencies", "onig_scanner.node");
 	// tslint:disable-next-line:no-unused-expression
 	require("../../protocol/node_modules/node-pty-prebuilt/lib/index") as typeof import("../../protocol/node_modules/node-pty-prebuilt/src/index");
 };

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -14,8 +14,8 @@ module.exports = merge(
 				loader: "string-replace-loader",
 				options: {
 					multiple: [{
-						search: "const Onig(.*) = .*onig_scanner\.node.*\.(.*)",
-						replace: "const Onig$1 = __non_webpack_require__(global.ONIG_LOCATION).$2;",
+						search: "const Onig(.*) = .*onig_scanner\.node.*\.Onig(.*)",
+						replace: "const Onig$1 = __non_webpack_require__(global.ONIG_LOCATION).Onig$2;",
 						flags: "g",
 					}],
 				},

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -8,6 +8,19 @@ module.exports = merge(
 	require(path.join(root, "scripts/webpack.node.config.js"))({
 		// Config options.
 	}), {
+		module: {
+			rules: [{
+				test: /oniguruma(\\|\/)src(\\|\/).*\.js/,
+				loader: "string-replace-loader",
+				options: {
+					multiple: [{
+						search: "const Onig(.*) = .*onig_scanner\.node.*\.(.*)",
+						replace: "const Onig$1 = __non_webpack_require__(global.ONIG_LOCATION).$2;",
+						flags: "g",
+					}],
+				},
+			}],
+		},
 		output: {
 			filename: "cli.js",
 			path: path.join(__dirname, "out"),


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

There was a 'vscode-textmate' dependency for the `CoenraadS.bracket-pair-colorizer-2` extension, which included 'oniguruma' as a dependency. This PR adds a section to the bootstrapFork module requirement which will allow the inclusion of dependencies that should exist with the unpacked version of VS Code.

### Is there an open issue you can link to?

https://github.com/codercom/code-server/issues/200#issuecomment-473182369
