### PR TITLE
Ensure workspace configPath is a valid URI object

### DIFF
--- a/packages/vscode/src/workbench.ts
+++ b/packages/vscode/src/workbench.ts
@@ -185,7 +185,13 @@ export class Workbench {
 			_: [],
 		};
 		if ((workspace as IWorkspaceIdentifier).configPath) {
-			config.workspace = workspace as IWorkspaceIdentifier;
+			// tslint:disable-next-line:no-any
+			let wid: IWorkspaceIdentifier = (<any>Object).assign({}, workspace);
+			if (!URI.isUri(wid.configPath)) {
+				// Ensure that the configPath is a valid URI.
+				wid.configPath = URI.file(wid.configPath);
+			}
+			config.workspace = wid;
 		} else {
 			config.folderUri = workspace as URI;
 		}


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
Adding a folder to a workspace results in a failure to reload the workspace. This was due to the workspace URI being invalid. The scheme (https://tools.ietf.org/html/rfc3986#section-3.1) for the URI was actually the path to the workspace configuration file, so the URI would always fail to parse upon workspace initialization.

This PR will ensure that the configuration path is actually defined as a valid `file://` URI, instead of simply casting it.

### Is there an open issue you can link to?
Fixes https://github.com/codercom/code-server/issues/309
