### PR TITLE
Watcher and initial load performance improvements

### DIFF
--- a/packages/protocol/src/browser/modules/fs.ts
+++ b/packages/protocol/src/browser/modules/fs.ts
@@ -98,9 +98,7 @@ export class FsModule {
 	}
 
 	public exists = (path: fs.PathLike, callback: (exists: boolean) => void): void => {
-		callbackify(this.proxy.exists)(path, (exists) => {
-			callback!(exists as any);
-		});
+		this.proxy.exists(path).then((exists) => callback(exists)).catch(() => callback(false));
 	}
 
 	public fchmod = (fd: number, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void => {

--- a/packages/protocol/src/browser/modules/fs.ts
+++ b/packages/protocol/src/browser/modules/fs.ts
@@ -1,11 +1,31 @@
 import * as fs from "fs";
 import { callbackify } from "util";
-import { ClientProxy } from "../../common/proxy";
+import { ClientProxy, Batch } from "../../common/proxy";
 import { IEncodingOptions, IEncodingOptionsCallback } from "../../common/util";
 import { FsModuleProxy, Stats as IStats, WatcherProxy, WriteStreamProxy } from "../../node/modules/fs";
 import { Writable  } from "./stream";
 
 // tslint:disable no-any
+
+class StatBatch extends Batch<IStats, { path: fs.PathLike }> {
+	public constructor(private readonly proxy: FsModuleProxy) {
+		super();
+	}
+
+	protected remoteCall(batch: { path: fs.PathLike }[]): Promise<(IStats | Error)[]> {
+		return this.proxy.statBatch(batch);
+	}
+}
+
+class ReaddirBatch extends Batch<Buffer[] | fs.Dirent[] | string[], { path: fs.PathLike, options: IEncodingOptions }> {
+	public constructor(private readonly proxy: FsModuleProxy) {
+		super();
+	}
+
+	protected remoteCall(queue: { path: fs.PathLike, options: IEncodingOptions }[]): Promise<(Buffer[] | fs.Dirent[] | string[] | Error)[]> {
+		return this.proxy.readdirBatch(queue);
+	}
+}
 
 class Watcher extends ClientProxy<WatcherProxy> implements fs.FSWatcher {
 	public close(): void {
@@ -28,7 +48,13 @@ class WriteStream extends Writable<WriteStreamProxy> implements fs.WriteStream {
 }
 
 export class FsModule {
-	public constructor(private readonly proxy: FsModuleProxy) {}
+	private readonly statBatch: StatBatch;
+	private readonly readdirBatch: ReaddirBatch;
+
+	public constructor(private readonly proxy: FsModuleProxy) {
+		this.statBatch = new StatBatch(this.proxy);
+		this.readdirBatch = new ReaddirBatch(this.proxy);
+	}
 
 	public access = (path: fs.PathLike, mode: number | undefined | ((err: NodeJS.ErrnoException) => void), callback?: (err: NodeJS.ErrnoException) => void): void => {
 		if (typeof mode === "function") {
@@ -175,7 +201,7 @@ export class FsModule {
 			callback = options;
 			options = undefined;
 		}
-		callbackify(this.proxy.readdir)(path, options, callback!);
+		callbackify(this.readdirBatch.add)({ path, options }, callback!);
 	}
 
 	public readlink = (path: fs.PathLike, options: IEncodingOptionsCallback, callback?: (err: NodeJS.ErrnoException, linkString: string | Buffer) => void): void => {
@@ -203,7 +229,7 @@ export class FsModule {
 	}
 
 	public stat = (path: fs.PathLike, callback: (err: NodeJS.ErrnoException, stats: fs.Stats) => void): void => {
-		callbackify(this.proxy.stat)(path, (error, stats) => {
+		callbackify(this.statBatch.add)({ path }, (error, stats) => {
 			callback(error, stats && new Stats(stats));
 		});
 	}

--- a/packages/protocol/src/node/modules/fs.ts
+++ b/packages/protocol/src/node/modules/fs.ts
@@ -157,7 +157,7 @@ export class FsModuleProxy {
 	}
 
 	public async lstatBatch(args: { path: fs.PathLike }[]): Promise<(Stats | Error)[]> {
-		return Promise.all(args.map((args) => this.lstat(args.path).catch((e) => e)));
+		return Promise.all(args.map((a) => this.lstat(a.path).catch((e) => e)));
 	}
 
 	public mkdir(path: fs.PathLike, mode: number | string | fs.MakeDirectoryOptions | undefined | null): Promise<void> {
@@ -187,7 +187,7 @@ export class FsModuleProxy {
 	}
 
 	public readdirBatch(args: { path: fs.PathLike, options: IEncodingOptions }[]): Promise<(Buffer[] | fs.Dirent[] | string[] | Error)[]> {
-		return Promise.all(args.map((args) => this.readdir(args.path, args.options).catch((e) => e)));
+		return Promise.all(args.map((a) => this.readdir(a.path, a.options).catch((e) => e)));
 	}
 
 	public readlink(path: fs.PathLike, options: IEncodingOptions): Promise<string | Buffer> {
@@ -211,7 +211,7 @@ export class FsModuleProxy {
 	}
 
 	public async statBatch(args: { path: fs.PathLike }[]): Promise<(Stats | Error)[]> {
-		return Promise.all(args.map((args) => this.stat(args.path).catch((e) => e)));
+		return Promise.all(args.map((a) => this.stat(a.path).catch((e) => e)));
 	}
 
 	public symlink(target: fs.PathLike, path: fs.PathLike, type?: fs.symlink.Type | null): Promise<void> {

--- a/packages/protocol/src/node/modules/fs.ts
+++ b/packages/protocol/src/node/modules/fs.ts
@@ -182,6 +182,10 @@ export class FsModuleProxy {
 		return promisify(fs.readdir)(path, options);
 	}
 
+	public readdirBatch(args: { path: fs.PathLike, options: IEncodingOptions }[]): Promise<(Buffer[] | fs.Dirent[] | string[] | Error)[]> {
+		return Promise.all(args.map((args) => this.readdir(args.path, args.options).catch((e) => e)));
+	}
+
 	public readlink(path: fs.PathLike, options: IEncodingOptions): Promise<string | Buffer> {
 		return promisify(fs.readlink)(path, options);
 	}
@@ -200,6 +204,10 @@ export class FsModuleProxy {
 
 	public async stat(path: fs.PathLike): Promise<Stats> {
 		return this.makeStatsSerializable(await promisify(fs.stat)(path));
+	}
+
+	public async statBatch(args: { path: fs.PathLike }[]): Promise<(Stats | Error)[]> {
+		return Promise.all(args.map((args) => this.stat(args.path).catch((e) => e)));
 	}
 
 	public symlink(target: fs.PathLike, path: fs.PathLike, type?: fs.symlink.Type | null): Promise<void> {

--- a/packages/protocol/src/node/modules/fs.ts
+++ b/packages/protocol/src/node/modules/fs.ts
@@ -156,6 +156,10 @@ export class FsModuleProxy {
 		return this.makeStatsSerializable(await promisify(fs.lstat)(path));
 	}
 
+	public async lstatBatch(args: { path: fs.PathLike }[]): Promise<(Stats | Error)[]> {
+		return Promise.all(args.map((args) => this.lstat(args.path).catch((e) => e)));
+	}
+
 	public mkdir(path: fs.PathLike, mode: number | string | fs.MakeDirectoryOptions | undefined | null): Promise<void> {
 		return promisify(fs.mkdir)(path, mode);
 	}


### PR DESCRIPTION
- [X] Set low CPU priority on the watcher on Linux (the lowest possible, 19).
- [X] Batch `stat` calls.
- [X] Batch `readdir` calls.
- [X] Batch `lstat` calls.

I benchmarked using `stat` across 10k files, with the current batch settings it seems to result in around a 1.5-1.9 increase in speed when ran locally. 

I'm not sure what the optimal batch size and timeout are, but I played around with how responsive the terminal felt and went with something that seemed reasonable. During load the terminal is much more responsive, but we might be able to further improve.

**Edit**: It looks like the remaining lag on the terminal during load is due to either the client parsing all the messages sent back to it from all the batched calls or the server stringifying all those messages (probably some of both). I suppose the only way to make it better is to somehow make `JSON.parse` and `JSON.stringify` asynchronous and low-priority for messages that don't need to be immediately responsive (maybe spawn a process or worker for those messages).

**Edit 2**: Moving *all* the parsing/stringifying to separate threads using processes/workers might be a good idea?