### PR TITLE
Handle disconnects

### DIFF
--- a/packages/protocol/src/browser/client.ts
+++ b/packages/protocol/src/browser/client.ts
@@ -176,6 +176,13 @@ export class Client {
 	 */
 	private async remoteCall(proxyId: number | Module, method: string, args: any[]): Promise<any> {
 		if (this.disconnected && typeof proxyId === "number") {
+			// Can assume killing or closing works because a disconnected proxy
+			// is disposed on the server's side.
+			switch (method) {
+				case "close":
+				case "kill":
+					return Promise.resolve();
+			}
 			return Promise.reject(
 				new Error(`Unable to call "${method}" on proxy ${proxyId}: disconnected`),
 			);

--- a/packages/protocol/src/browser/client.ts
+++ b/packages/protocol/src/browser/client.ts
@@ -143,7 +143,12 @@ export class Client {
 			clearTimeout(this.pingTimeout as any);
 			this.pingTimeout = undefined;
 			handleDisconnect();
-			this.dispose();
+			this.proxies.clear();
+			this.successEmitter.dispose();
+			this.failEmitter.dispose();
+			this.eventEmitter.dispose();
+			this.initDataEmitter.dispose();
+			this.sharedProcessActiveEmitter.dispose();
 		});
 		connection.onUp(() => this.disconnected = false);
 
@@ -159,12 +164,6 @@ export class Client {
 	 */
 	public dispose(): void {
 		this.connection.close();
-		this.proxies.clear();
-		this.successEmitter.dispose();
-		this.failEmitter.dispose();
-		this.eventEmitter.dispose();
-		this.initDataEmitter.dispose();
-		this.sharedProcessActiveEmitter.dispose();
 	}
 
 	public get initData(): Promise<InitData> {

--- a/packages/protocol/src/browser/client.ts
+++ b/packages/protocol/src/browser/client.ts
@@ -174,7 +174,7 @@ export class Client {
 	/**
 	 * Make a remote call for a proxy's method using proto.
 	 */
-	private async remoteCall(proxyId: number | Module, method: string, args: any[]): Promise<any> {
+	private remoteCall(proxyId: number | Module, method: string, args: any[]): Promise<any> {
 		if (this.disconnected && typeof proxyId === "number") {
 			// Can assume killing or closing works because a disconnected proxy
 			// is disposed on the server's side.
@@ -247,7 +247,7 @@ export class Client {
 
 			const d1 = this.successEmitter.event(id, (message) => {
 				dispose();
-				resolve(this.parse(message.getResponse()));
+				resolve(this.parse(message.getResponse(), promise));
 			});
 
 			const d2 = this.failEmitter.event(id, (message) => {

--- a/packages/protocol/src/browser/modules/child_process.ts
+++ b/packages/protocol/src/browser/modules/child_process.ts
@@ -87,6 +87,16 @@ export class ChildProcess extends ClientProxy<ChildProcessProxy> implements cp.C
 
 		return true; // Always true since we can't get this synchronously.
 	}
+
+	protected handleDisconnect(error: Error): void {
+		try {
+			this.emit("error", error);
+		} catch (error) {
+			// If nothing is listening, EventEmitter will throw an error.
+		}
+		this.emit("exit", 1);
+		this.emit("close");
+	}
 }
 
 export class ChildProcessModule {

--- a/packages/protocol/src/browser/modules/child_process.ts
+++ b/packages/protocol/src/browser/modules/child_process.ts
@@ -88,12 +88,7 @@ export class ChildProcess extends ClientProxy<ChildProcessProxy> implements cp.C
 		return true; // Always true since we can't get this synchronously.
 	}
 
-	protected handleDisconnect(error: Error): void {
-		try {
-			this.emit("error", error);
-		} catch (error) {
-			// If nothing is listening, EventEmitter will throw an error.
-		}
+	protected handleDisconnect(): void {
 		this.emit("exit", 1);
 		this.emit("close");
 	}

--- a/packages/protocol/src/browser/modules/fs.ts
+++ b/packages/protocol/src/browser/modules/fs.ts
@@ -41,6 +41,15 @@ class Watcher extends ClientProxy<WatcherProxy> implements fs.FSWatcher {
 	public close(): void {
 		this.proxy.close();
 	}
+
+	protected handleDisconnect(error: Error): void {
+		try {
+			this.emit("error", error);
+		} catch (error) {
+			// If nothing is listening, EventEmitter will throw an error.
+		}
+		this.emit("close");
+	}
 }
 
 class WriteStream extends Writable<WriteStreamProxy> implements fs.WriteStream {

--- a/packages/protocol/src/browser/modules/fs.ts
+++ b/packages/protocol/src/browser/modules/fs.ts
@@ -42,12 +42,7 @@ class Watcher extends ClientProxy<WatcherProxy> implements fs.FSWatcher {
 		this.proxy.close();
 	}
 
-	protected handleDisconnect(error: Error): void {
-		try {
-			this.emit("error", error);
-		} catch (error) {
-			// If nothing is listening, EventEmitter will throw an error.
-		}
+	protected handleDisconnect(): void {
 		this.emit("close");
 	}
 }

--- a/packages/protocol/src/browser/modules/net.ts
+++ b/packages/protocol/src/browser/modules/net.ts
@@ -207,12 +207,7 @@ export class Server extends ClientProxy<NetServerProxy> implements net.Server {
 		cb(null, this.sockets.size);
 	}
 
-	protected handleDisconnect(error: Error): void {
-		try {
-			this.emit("error", error);
-		} catch (error) {
-			// If nothing is listening, EventEmitter will throw an error.
-		}
+	protected handleDisconnect(): void {
 		this.emit("close");
 	}
 }

--- a/packages/protocol/src/browser/modules/node-pty.ts
+++ b/packages/protocol/src/browser/modules/node-pty.ts
@@ -32,6 +32,11 @@ export class NodePtyProcess extends ClientProxy<NodePtyProcessProxy> implements 
 	public kill(signal?: string): void {
 		this.proxy.kill(signal);
 	}
+
+	protected handleDisconnect(): void {
+		this._process += " (disconnected)";
+		this.emit("data", "\r\n\nLost connection...");
+	}
 }
 
 type NodePty = typeof pty;

--- a/packages/protocol/src/browser/modules/spdlog.ts
+++ b/packages/protocol/src/browser/modules/spdlog.ts
@@ -13,6 +13,10 @@ class RotatingLogger extends ClientProxy<RotatingLoggerProxy> implements spdlog.
 	public async clearFormatters (): Promise<void> { this.proxy.clearFormatters(); }
 	public async flush (): Promise<void> { this.proxy.flush(); }
 	public async drop (): Promise<void> { this.proxy.drop(); }
+
+	protected handleDisconnect(): void {
+		// TODO: reconnect.
+	}
 }
 
 export class SpdlogModule {

--- a/packages/protocol/src/browser/modules/spdlog.ts
+++ b/packages/protocol/src/browser/modules/spdlog.ts
@@ -3,6 +3,16 @@ import { ClientProxy } from "../../common/proxy";
 import { RotatingLoggerProxy, SpdlogModuleProxy } from "../../node/modules/spdlog";
 
 class RotatingLogger extends ClientProxy<RotatingLoggerProxy> implements spdlog.RotatingLogger {
+	public constructor(
+		private readonly moduleProxy: SpdlogModuleProxy,
+		private readonly name: string,
+		private readonly filename: string,
+		private readonly filesize: number,
+		private readonly filecount: number,
+	) {
+		super(moduleProxy.createLogger(name, filename, filesize, filecount));
+	}
+
 	public async trace (message: string): Promise<void> { this.proxy.trace(message); }
 	public async debug (message: string): Promise<void> { this.proxy.debug(message); }
 	public async info (message: string): Promise<void> { this.proxy.info(message); }
@@ -15,7 +25,7 @@ class RotatingLogger extends ClientProxy<RotatingLoggerProxy> implements spdlog.
 	public async drop (): Promise<void> { this.proxy.drop(); }
 
 	protected handleDisconnect(): void {
-		// TODO: reconnect.
+		this.initialize(this.moduleProxy.createLogger(this.name, this.filename, this.filesize, this.filecount));
 	}
 }
 
@@ -25,7 +35,7 @@ export class SpdlogModule {
 	public constructor(private readonly proxy: SpdlogModuleProxy) {
 		this.RotatingLogger = class extends RotatingLogger {
 			public constructor(name: string, filename: string, filesize: number, filecount: number) {
-				super(proxy.createLogger(name, filename, filesize, filecount));
+				super(proxy, name, filename, filesize, filecount);
 			}
 		};
 	}

--- a/packages/protocol/src/browser/modules/stream.ts
+++ b/packages/protocol/src/browser/modules/stream.ts
@@ -81,6 +81,16 @@ export class Writable<T extends WritableProxy = WritableProxy> extends ClientPro
 			}
 		});
 	}
+
+	protected handleDisconnect(error: Error): void {
+		try {
+			this.emit("error", error);
+		} catch (error) {
+			// If nothing is listening, EventEmitter will throw an error.
+		}
+		this.emit("close");
+		this.emit("finish");
+	}
 }
 
 export class Readable<T extends IReadableProxy = IReadableProxy> extends ClientProxy<T> implements stream.Readable {
@@ -153,6 +163,16 @@ export class Readable<T extends IReadableProxy = IReadableProxy> extends ClientP
 		this.proxy.setEncoding(encoding);
 
 		return this;
+	}
+
+	protected handleDisconnect(error: Error): void {
+		try {
+			this.emit("error", error);
+		} catch (error) {
+			// If nothing is listening, EventEmitter will throw an error.
+		}
+		this.emit("close");
+		this.emit("end");
 	}
 }
 
@@ -229,5 +249,10 @@ export class Duplex<T extends DuplexProxy = DuplexProxy> extends Writable<T> imp
 		this.proxy.setEncoding(encoding);
 
 		return this;
+	}
+
+	protected handleDisconnect(error: Error): void {
+		super.handleDisconnect(error);
+		this.emit("end");
 	}
 }

--- a/packages/protocol/src/browser/modules/stream.ts
+++ b/packages/protocol/src/browser/modules/stream.ts
@@ -82,12 +82,7 @@ export class Writable<T extends WritableProxy = WritableProxy> extends ClientPro
 		});
 	}
 
-	protected handleDisconnect(error: Error): void {
-		try {
-			this.emit("error", error);
-		} catch (error) {
-			// If nothing is listening, EventEmitter will throw an error.
-		}
+	protected handleDisconnect(): void {
 		this.emit("close");
 		this.emit("finish");
 	}
@@ -165,12 +160,7 @@ export class Readable<T extends IReadableProxy = IReadableProxy> extends ClientP
 		return this;
 	}
 
-	protected handleDisconnect(error: Error): void {
-		try {
-			this.emit("error", error);
-		} catch (error) {
-			// If nothing is listening, EventEmitter will throw an error.
-		}
+	protected handleDisconnect(): void {
 		this.emit("close");
 		this.emit("end");
 	}
@@ -251,8 +241,8 @@ export class Duplex<T extends DuplexProxy = DuplexProxy> extends Writable<T> imp
 		return this;
 	}
 
-	protected handleDisconnect(error: Error): void {
-		super.handleDisconnect(error);
+	protected handleDisconnect(): void {
+		super.handleDisconnect();
 		this.emit("end");
 	}
 }

--- a/packages/protocol/src/common/proxy.ts
+++ b/packages/protocol/src/common/proxy.ts
@@ -42,8 +42,11 @@ export abstract class ClientProxy<T extends ServerProxy> extends EventEmitter {
 			this.proxy.onEvent((event, ...args): void => {
 				this.emit(event, ...args);
 			});
+			this.on("disconnected", (error) => this.handleDisconnect(error));
 		}
 	}
+
+	protected abstract handleDisconnect(error: Error): void;
 }
 
 /**

--- a/packages/protocol/src/common/proxy.ts
+++ b/packages/protocol/src/common/proxy.ts
@@ -42,7 +42,14 @@ export abstract class ClientProxy<T extends ServerProxy> extends EventEmitter {
 		super();
 		this.initialize(proxyPromise);
 		if (this.bindEvents) {
-			this.on("disconnected", (error) => this.handleDisconnect(error));
+			this.on("disconnected", (error) => {
+				try {
+					this.emit("error", error);
+				} catch (error) {
+					// If nothing is listening, EventEmitter will throw an error.
+				}
+				this.handleDisconnect();
+			});
 		}
 	}
 
@@ -63,7 +70,7 @@ export abstract class ClientProxy<T extends ServerProxy> extends EventEmitter {
 		}
 	}
 
-	protected abstract handleDisconnect(error: Error): void;
+	protected abstract handleDisconnect(): void;
 }
 
 /**

--- a/packages/protocol/src/node/server.ts
+++ b/packages/protocol/src/node/server.ts
@@ -138,7 +138,7 @@ export class Server {
 
 		let response: any;
 		try {
-			const proxy = this.getProxy(proxyId);
+			const proxy = this.getProxy(proxyId, method);
 			if (typeof proxy.instance[method] !== "function") {
 				throw new Error(`"${method}" is not a function`);
 			}
@@ -231,7 +231,7 @@ export class Server {
 				// It might have finished because we disposed it due to a disconnect.
 				if (!this.disconnected) {
 					this.sendEvent(proxyId, "done");
-					this.getProxy(proxyId).disposeTimeout = setTimeout(() => {
+					this.getProxy(proxyId, "disposeTimeout").disposeTimeout = setTimeout(() => {
 						instance.dispose();
 						this.removeProxy(proxyId);
 					}, this.responseTimeout);
@@ -317,7 +317,7 @@ export class Server {
 	 * Call after disposing a proxy.
 	 */
 	private removeProxy(proxyId: number | Module): void {
-		clearTimeout(this.getProxy(proxyId).disposeTimeout as any);
+		clearTimeout(this.getProxy(proxyId, "disposeTimeout").disposeTimeout as any);
 		this.proxies.delete(proxyId);
 
 		logger.trace(() => [
@@ -331,9 +331,9 @@ export class Server {
 		return stringify(value, undefined, (p) => this.storeProxy(p));
 	}
 
-	private getProxy(proxyId: number | Module): ProxyData {
+	private getProxy(proxyId: number | Module, method: string): ProxyData {
 		if (!this.proxies.has(proxyId)) {
-			throw new Error(`proxy ${proxyId} disposed too early`);
+			throw new Error(`Cannot run "${method}" on proxy ${proxyId}: proxy does not exist`);
 		}
 
 		return this.proxies.get(proxyId)!;

--- a/packages/protocol/src/node/server.ts
+++ b/packages/protocol/src/node/server.ts
@@ -138,7 +138,7 @@ export class Server {
 
 		let response: any;
 		try {
-			const proxy = this.getProxy(proxyId, method);
+			const proxy = this.getProxy(proxyId);
 			if (typeof proxy.instance[method] !== "function") {
 				throw new Error(`"${method}" is not a function on proxy ${proxyId}`);
 			}
@@ -231,7 +231,7 @@ export class Server {
 				// It might have finished because we disposed it due to a disconnect.
 				if (!this.disconnected) {
 					this.sendEvent(proxyId, "done");
-					this.getProxy(proxyId, "disposeTimeout").disposeTimeout = setTimeout(() => {
+					this.getProxy(proxyId).disposeTimeout = setTimeout(() => {
 						instance.dispose();
 						this.removeProxy(proxyId);
 					}, this.responseTimeout);
@@ -317,7 +317,7 @@ export class Server {
 	 * Call after disposing a proxy.
 	 */
 	private removeProxy(proxyId: number | Module): void {
-		clearTimeout(this.getProxy(proxyId, "disposeTimeout").disposeTimeout as any);
+		clearTimeout(this.getProxy(proxyId).disposeTimeout as any);
 		this.proxies.delete(proxyId);
 
 		logger.trace(() => [
@@ -331,9 +331,9 @@ export class Server {
 		return stringify(value, undefined, (p) => this.storeProxy(p));
 	}
 
-	private getProxy(proxyId: number | Module, method: string): ProxyData {
+	private getProxy(proxyId: number | Module): ProxyData {
 		if (!this.proxies.has(proxyId)) {
-			throw new Error(`Cannot run "${method}" on proxy ${proxyId}: proxy does not exist`);
+			throw new Error(`proxy ${proxyId} disposed too early`);
 		}
 
 		return this.proxies.get(proxyId)!;

--- a/packages/protocol/src/node/server.ts
+++ b/packages/protocol/src/node/server.ts
@@ -140,7 +140,7 @@ export class Server {
 		try {
 			const proxy = this.getProxy(proxyId, method);
 			if (typeof proxy.instance[method] !== "function") {
-				throw new Error(`"${method}" is not a function`);
+				throw new Error(`"${method}" is not a function on proxy ${proxyId}`);
 			}
 
 			response = proxy.instance[method](...args);

--- a/packages/vscode/src/workbench.ts
+++ b/packages/vscode/src/workbench.ts
@@ -30,6 +30,8 @@ import { ServiceCollection } from "vs/platform/instantiation/common/serviceColle
 import { URI } from "vs/base/common/uri";
 
 export class Workbench {
+	public readonly retry = client.retry;
+
 	private readonly windowId = parseInt(new Date().toISOString().replace(/[-:.TZ]/g, ""), 10);
 	private _serviceCollection: ServiceCollection | undefined;
 	private _clipboardContextKey: RawContextKey<boolean> | undefined;

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -922,29 +922,31 @@ index 484cef9..f728fc8 100644
 -					process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
 +					// process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
 diff --git a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
-index ca03fc9..b8befc8 100644
+index ca03fc9..e3dcd08 100644
 --- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
 +++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
 @@ -18,0 +19 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
 +const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
 @@ -35,0 +37 @@ export class FileWatcher {
 +		retry.register('Watcher', () => this.startWatching());
-@@ -56,0 +59 @@ export class FileWatcher {
+@@ -56,0 +59,2 @@ export class FileWatcher {
++				this.toDispose = dispose(this.toDispose);
 +				return retry.run('Watcher');
-@@ -113 +116 @@ export class FileWatcher {
+@@ -113 +117 @@ export class FileWatcher {
 -		}));
 +		})).then(() => retry.recover('Watcher'));
 diff --git a/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts b/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
-index 7e3a324..0bc5aac 100644
+index 7e3a324..b9ccd63 100644
 --- a/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
 +++ b/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
 @@ -18,0 +19 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
 +const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
 @@ -36,0 +38 @@ export class FileWatcher {
 +		retry.register('Watcher', () => this.startWatching());
-@@ -59,0 +62 @@ export class FileWatcher {
+@@ -59,0 +62,2 @@ export class FileWatcher {
++				this.toDispose = dispose(this.toDispose);
 +				return retry.run('Watcher');
-@@ -116 +119 @@ export class FileWatcher {
+@@ -116 +120 @@ export class FileWatcher {
 -		}));
 +		})).then(() => retry.recover('Watcher'));
 diff --git a/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts b/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts
@@ -969,6 +971,40 @@ index 3c78990..545d91a 100644
 @@ -130 +130 @@ export class KeyboardMapperFactory {
 -		if (OS === OperatingSystem.Windows) {
 +		if (isNative && OS === OperatingSystem.Windows) {
+diff --git a/src/vs/workbench/services/search/node/searchService.ts b/src/vs/workbench/services/search/node/searchService.ts
+index 3eaafa4..0345bad 100644
+--- a/src/vs/workbench/services/search/node/searchService.ts
++++ b/src/vs/workbench/services/search/node/searchService.ts
+@@ -11 +11 @@ import { Event } from 'vs/base/common/event';
+-import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
++import { Disposable, IDisposable, toDisposable, dispose } from 'vs/base/common/lifecycle';
+@@ -32,0 +33 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
++const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
+@@ -433,0 +435 @@ export class DiskSearch implements ISearchResultProvider {
++	private toDispose: IDisposable[] = [];
+@@ -470,6 +472,16 @@ export class DiskSearch implements ISearchResultProvider {
+-		const client = new Client(
+-			getPathFromAmdModule(require, 'bootstrap-fork'),
+-			opts);
+-
+-		const channel = getNextTickChannel(client.getChannel('search'));
+-		this.raw = new SearchChannelClient(channel);
++		const connect = (): void => {
++			const client = new Client(
++				getPathFromAmdModule(require, 'bootstrap-fork'),
++				opts);
++			client.onDidProcessExit(() => {
++				this.toDispose = dispose(this.toDispose);
++				retry.run('Searcher');
++			}, null, this.toDispose);
++			this.toDispose.push(client);
++
++			const channel = getNextTickChannel(client.getChannel('search'));
++			this.raw = new SearchChannelClient(channel);
++			this.raw.clearCache('test-connectivity').then(() => retry.recover('Searcher'));
++		};
++		retry.register('Searcher', connect);
++		connect();
 diff --git a/src/vs/workbench/services/timer/electron-browser/timerService.ts b/src/vs/workbench/services/timer/electron-browser/timerService.ts
 index 6e6fbcc..645bd72 100644
 --- a/src/vs/workbench/services/timer/electron-browser/timerService.ts

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -921,6 +921,44 @@ index 484cef9..f728fc8 100644
 @@ -137 +137 @@ function connectToRenderer(protocol: IMessagePassingProtocol): Promise<IRenderer
 -					process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
 +					// process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
+diff --git a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
+index ca03fc9..b8befc8 100644
+--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
++++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
+@@ -18,0 +19 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
++const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
+@@ -35,0 +37 @@ export class FileWatcher {
++		retry.register('Watcher', () => this.startWatching());
+@@ -56,0 +59 @@ export class FileWatcher {
++				return retry.run('Watcher');
+@@ -113 +116 @@ export class FileWatcher {
+-		}));
++		})).then(() => retry.recover('Watcher'));
+diff --git a/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts b/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
+index 7e3a324..0bc5aac 100644
+--- a/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
++++ b/src/vs/workbench/services/files/node/watcher/unix/watcherService.ts
+@@ -18,0 +19 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
++const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
+@@ -36,0 +38 @@ export class FileWatcher {
++		retry.register('Watcher', () => this.startWatching());
+@@ -59,0 +62 @@ export class FileWatcher {
++				return retry.run('Watcher');
+@@ -116 +119 @@ export class FileWatcher {
+-		}));
++		})).then(() => retry.recover('Watcher'));
+diff --git a/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts b/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts
+index 74dad64..34cd83b 100644
+--- a/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts
++++ b/src/vs/workbench/services/files/node/watcher/win32/csharpWatcherService.ts
+@@ -14,0 +15 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
++const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
+@@ -40,0 +42 @@ export class OutOfProcessWin32FolderWatcher {
++		retry.register('Watcher', () => this.startWatcher());
+@@ -52,0 +55 @@ export class OutOfProcessWin32FolderWatcher {
++		this.handle.stdout.once('data', () => retry.recover('Watcher'));
+@@ -110,0 +114 @@ export class OutOfProcessWin32FolderWatcher {
++			return retry.run('Watcher');
 diff --git a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
 index 3c78990..545d91a 100644
 --- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -883,7 +883,7 @@ index acb68c8..bee143a 100644
 -			!isMacintosh || // macOS only
 +			!browser.isMacintosh || // macOS only
 diff --git a/src/vs/workbench/electron-browser/workbench.ts b/src/vs/workbench/electron-browser/workbench.ts
-index 7445d7b..0291dee 100644
+index 7445d7b..ba6bf4b 100644
 --- a/src/vs/workbench/electron-browser/workbench.ts
 +++ b/src/vs/workbench/electron-browser/workbench.ts
 @@ -19 +19,2 @@ import { Registry } from 'vs/platform/registry/common/platform';
@@ -899,13 +899,15 @@ index 7445d7b..0291dee 100644
 @@ -458 +462 @@ export class Workbench extends Disposable implements IPartService {
 -		addClasses(document.body, platformClass); // used by our fonts
 +		addClasses(document.body, platformClass, isWeb ? 'web' : 'native'); // used by our fonts
-@@ -633 +637 @@ export class Workbench extends Disposable implements IPartService {
+@@ -491,0 +496 @@ export class Workbench extends Disposable implements IPartService {
++				client.onClose(() => this.notificationService.error("Disconnected from shared process. Searching, installing, enabling, and disabling extensions will not work until the page is refreshed."));
+@@ -633 +638 @@ export class Workbench extends Disposable implements IPartService {
 -		if (!isMacintosh && this.useCustomTitleBarStyle()) {
 +		if (isWeb || (!isMacintosh && this.useCustomTitleBarStyle())) {
-@@ -1241 +1245 @@ export class Workbench extends Disposable implements IPartService {
+@@ -1241 +1246 @@ export class Workbench extends Disposable implements IPartService {
 -		if ((isWindows || isLinux) && this.useCustomTitleBarStyle()) {
 +		if ((isWeb || isWindows || isLinux) && this.useCustomTitleBarStyle()) {
-@@ -1397 +1401 @@ export class Workbench extends Disposable implements IPartService {
+@@ -1397 +1402 @@ export class Workbench extends Disposable implements IPartService {
 -				} else if (isMacintosh) {
 +				} else if (isNative && isMacintosh) {
 diff --git a/src/vs/workbench/services/extensions/electron-browser/cachedExtensionScanner.ts b/src/vs/workbench/services/extensions/electron-browser/cachedExtensionScanner.ts

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -914,6 +914,18 @@ index 0592910..0ce7e35 100644
 +++ b/src/vs/workbench/services/extensions/electron-browser/cachedExtensionScanner.ts
 @@ -33,0 +34 @@ function getSystemExtensionsRoot(): string {
 +	return (require('vs/../../../../packages/vscode/src/fill/paths') as typeof import ('vs/../../../../packages/vscode/src/fill/paths')).getBuiltInExtensionsDirectory();
+diff --git a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+index 2c2f9c7..69fa321 100644
+--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
++++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+@@ -34,0 +35 @@ import { Schemas } from 'vs/base/common/network';
++const retry = (require('vs/../../../../packages/vscode/src/workbench') as typeof import ('vs/../../../../packages/vscode/src/workbench')).workbench.retry;
+@@ -117,0 +119 @@ export class ExtensionService extends Disposable implements IExtensionService {
++		retry.register('Extension Host', () => this.startExtensionHost());
+@@ -435,0 +438 @@ export class ExtensionService extends Disposable implements IExtensionService {
++		extHostProcessWorker.start().then(() => retry.recover('Extension Host'));
+@@ -458,0 +462 @@ export class ExtensionService extends Disposable implements IExtensionService {
++		return retry.run('Extension Host');
 diff --git a/src/vs/workbench/services/extensions/node/extensionHostProcess.ts b/src/vs/workbench/services/extensions/node/extensionHostProcess.ts
 index 484cef9..f728fc8 100644
 --- a/src/vs/workbench/services/extensions/node/extensionHostProcess.ts


### PR DESCRIPTION
We already reconnect the web socket when it drops but we also need to restart/reconnect services that started before the disconnection.

This PR will do that for the following:
- [X] Terminal instances (just spawn a new instance for now)
- [x] Extension host (already supported, just make it automatic)
- [x] Watcher (already supported, but need to use our retry for it)
- [x] Searcher
- [x] spdlog instances

Won't be in this PR:
- Shared process

Other:
- [x] Show message when the shared process dies explaining what won't work while it's dead and to restart/refresh the page for now if you need any of that.