### PR TITLE
Fix icons on safari when using cookie authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "typescript": "^3.2.2",
     "typescript-tslint-plugin": "^0.2.1",
     "uglifyjs-webpack-plugin": "^2.1.1",
+    "url-loader": "^1.1.2",
     "util": "^0.11.1",
     "webpack": "^4.28.4",
     "webpack-bundle-analyzer": "^3.0.3",

--- a/scripts/webpack.client.config.js
+++ b/scripts/webpack.client.config.js
@@ -30,13 +30,16 @@ module.exports = (options = {}) => merge(
 				loader: "sass-loader",
 			}],
 		}, {
-			test: /\.(svg|png|ttf|woff|eot|woff2)$/,
+			test: /\.(png|ttf|woff|eot|woff2)$/,
 			use: [{
 				loader: "file-loader",
 				options: {
 					name: "[path][name].[ext]",
 				},
 			}],
+		}, {
+			test: /\.svg$/,
+			loader: 'url-loader'
 		}],
 	},
 	plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,7 +3121,7 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^2.3.1:
+mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
   integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
@@ -5235,6 +5235,15 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-loader@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"
+  integrity sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==
+  dependencies:
+    loader-utils "^1.1.0"
+    mime "^2.0.3"
+    schema-utils "^1.0.0"
 
 url-parse@^1.4.3:
   version "1.4.4"


### PR DESCRIPTION
Cookie's are not sent with url's in -webkit-mask so we
embed the svg's directly in the css.