### PR TITLE
Use an init system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN apt-get update && apt-get install -y \
 	openssl \
 	net-tools \
 	git \
-	locales
+	locales \
+	dumb-init
 RUN locale-gen en_US.UTF-8
 # We unfortunately cannot use update-locale because docker will not use the env variables
 # configured in /etc/default/locale so we need to set it manually.
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8 
-ENTRYPOINT ["code-server"]
+ENTRYPOINT ["/usr/bin/dumb-init", "code-server"]


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it

While using docker container the user can not send POSIX commands like SIGKILL (CTR+C) or SIGTERM to code-server, causing the server to continue running in the background. Best practice in this case is to run an init system.

If a users wants to run the application in the background they should use docker run's `-d` flag
```bash
docker run -d codercom/code-server code-server --allow-http --no-auth
```
[dumb-init documentation](https://github.com/Yelp/dumb-init)

### Is there an open issue you can link to?

#361 
#383 