### PR TITLE
Add flags for customizing user data dir and extensions dir

### DIFF
--- a/packages/protocol/src/browser/client.ts
+++ b/packages/protocol/src/browser/client.ts
@@ -271,6 +271,7 @@ export class Client {
 					workingDirectory: init.getWorkingDirectory(),
 					os: protoToOperatingSystem(init.getOperatingSystem()),
 					shell: init.getShell(),
+					extensionsDirectory: init.getExtensionsDirectory(),
 					builtInExtensionsDirectory: init.getBuiltinExtensionsDir(),
 				};
 				this.initDataEmitter.emit(this._initData);

--- a/packages/protocol/src/common/connection.ts
+++ b/packages/protocol/src/common/connection.ts
@@ -23,6 +23,7 @@ export interface InitData {
 	readonly homeDirectory: string;
 	readonly tmpDirectory: string;
 	readonly shell: string;
+	readonly extensionsDirectory: string;
 	readonly builtInExtensionsDirectory: string;
 }
 

--- a/packages/protocol/src/node/server.ts
+++ b/packages/protocol/src/node/server.ts
@@ -14,6 +14,7 @@ export interface ServerOptions {
 	readonly dataDirectory: string;
 	readonly cacheDirectory: string;
 	readonly builtInExtensionsDirectory: string;
+	readonly extensionsDirectory: string;
 	readonly fork?: ForkProvider;
 }
 
@@ -93,6 +94,7 @@ export class Server {
 		initMsg.setDataDirectory(this.options.dataDirectory);
 		initMsg.setWorkingDirectory(this.options.workingDirectory);
 		initMsg.setBuiltinExtensionsDir(this.options.builtInExtensionsDirectory);
+		initMsg.setExtensionsDirectory(this.options.extensionsDirectory);
 		initMsg.setHomeDirectory(os.homedir());
 		initMsg.setTmpDirectory(os.tmpdir());
 		initMsg.setOperatingSystem(platformToProto(os.platform()));

--- a/packages/protocol/src/proto/client.proto
+++ b/packages/protocol/src/proto/client.proto
@@ -41,4 +41,5 @@ message WorkingInit {
 	OperatingSystem operating_system = 5;
 	string shell = 6;
 	string builtin_extensions_dir = 7;
+	string extensions_directory = 8;
 }

--- a/packages/protocol/src/proto/client_pb.d.ts
+++ b/packages/protocol/src/proto/client_pb.d.ts
@@ -132,6 +132,9 @@ export class WorkingInit extends jspb.Message {
   getBuiltinExtensionsDir(): string;
   setBuiltinExtensionsDir(value: string): void;
 
+  getExtensionsDirectory(): string;
+  setExtensionsDirectory(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): WorkingInit.AsObject;
   static toObject(includeInstance: boolean, msg: WorkingInit): WorkingInit.AsObject;
@@ -151,6 +154,7 @@ export namespace WorkingInit {
     operatingSystem: WorkingInit.OperatingSystem,
     shell: string,
     builtinExtensionsDir: string,
+    extensionsDirectory: string,
   }
 
   export enum OperatingSystem {

--- a/packages/protocol/src/proto/client_pb.js
+++ b/packages/protocol/src/proto/client_pb.js
@@ -794,7 +794,8 @@ proto.WorkingInit.toObject = function(includeInstance, msg) {
     workingDirectory: jspb.Message.getFieldWithDefault(msg, 4, ""),
     operatingSystem: jspb.Message.getFieldWithDefault(msg, 5, 0),
     shell: jspb.Message.getFieldWithDefault(msg, 6, ""),
-    builtinExtensionsDir: jspb.Message.getFieldWithDefault(msg, 7, "")
+    builtinExtensionsDir: jspb.Message.getFieldWithDefault(msg, 7, ""),
+    extensionsDirectory: jspb.Message.getFieldWithDefault(msg, 8, "")
   };
 
   if (includeInstance) {
@@ -858,6 +859,10 @@ proto.WorkingInit.deserializeBinaryFromReader = function(msg, reader) {
     case 7:
       var value = /** @type {string} */ (reader.readString());
       msg.setBuiltinExtensionsDir(value);
+      break;
+    case 8:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setExtensionsDirectory(value);
       break;
     default:
       reader.skipField();
@@ -934,6 +939,13 @@ proto.WorkingInit.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeString(
       7,
+      f
+    );
+  }
+  f = message.getExtensionsDirectory();
+  if (f.length > 0) {
+    writer.writeString(
+      8,
       f
     );
   }
@@ -1051,6 +1063,21 @@ proto.WorkingInit.prototype.getBuiltinExtensionsDir = function() {
 /** @param {string} value */
 proto.WorkingInit.prototype.setBuiltinExtensionsDir = function(value) {
   jspb.Message.setProto3StringField(this, 7, value);
+};
+
+
+/**
+ * optional string extensions_directory = 8;
+ * @return {string}
+ */
+proto.WorkingInit.prototype.getExtensionsDirectory = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, ""));
+};
+
+
+/** @param {string} value */
+proto.WorkingInit.prototype.setExtensionsDirectory = function(value) {
+  jspb.Message.setProto3StringField(this, 8, value);
 };
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,7 @@
 		"build:binary": "ts-node scripts/nbin.ts"
 	},
 	"dependencies": {
-		"@coder/nbin": "^1.0.4",
+		"@coder/nbin": "^1.0.5",
 		"commander": "^2.19.0",
 		"express": "^4.16.4",
 		"express-static-gzip": "^1.1.3",

--- a/packages/server/src/vscode/sharedProcess.ts
+++ b/packages/server/src/vscode/sharedProcess.ts
@@ -38,6 +38,7 @@ export class SharedProcess {
 
 	public constructor(
 		private readonly userDataDir: string,
+		private readonly extensionsDir: string,
 		private readonly builtInExtensionsDir: string,
 	) {
 		this.retry.run();
@@ -95,10 +96,8 @@ export class SharedProcess {
 			this.activeProcess.kill();
 		}
 
-		const extensionsDir = path.join(this.userDataDir, "extensions");
 		const backupsDir = path.join(this.userDataDir, "Backups");
 		await Promise.all([
-			fse.mkdirp(extensionsDir),
 			fse.mkdirp(backupsDir),
 		]);
 
@@ -141,7 +140,7 @@ export class SharedProcess {
 					args: {
 						"builtin-extensions-dir": this.builtInExtensionsDir,
 						"user-data-dir": this.userDataDir,
-						"extensions-dir": extensionsDir,
+						"extensions-dir": this.extensionsDir,
 					},
 					logLevel: this.logger.level,
 					sharedIPCHandle: this.socketPath,

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@coder/logger/-/logger-1.0.3.tgz#e0e1ae5496fde5a3c6ef3d748fdfb26a55add8b8"
   integrity sha512-1o5qDZX2VZUNnzgz5KfAdMnaqaX6FNeTs0dUdg73MRHfQW94tFTIryFC1xTTCuzxGDjVHOHkaUAI4uHA2bheOA==
 
-"@coder/nbin@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@coder/nbin/-/nbin-1.0.4.tgz#13a3d110fe116ed5d5fdbd1384f0335745dfd859"
-  integrity sha512-mtd5hzPHWBwKpTCYdJdLdiY4CFCEb8HUtv3NgH8SSLFiPDwY7H1UlpqeamIty27NZ+9NLnrBd/DfaE3aVo7rxQ==
+"@coder/nbin@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@coder/nbin/-/nbin-1.0.5.tgz#6a9e9982eb179d6bcc9c2e7dfebb608b7c4605d9"
+  integrity sha512-rai1/WgvH2j8SlRweOSk0JmrAzBx8bc22P+pThnPHj5terd0GScshqNR3EIoL/cdC2Ii4wjfOYodYbl/QynYGg==
   dependencies:
     "@coder/logger" "^1.0.3"
     fs-extra "^7.0.1"

--- a/packages/vscode/src/fill/environmentService.ts
+++ b/packages/vscode/src/fill/environmentService.ts
@@ -8,7 +8,7 @@ export class EnvironmentService extends environment.EnvironmentService {
 	}
 
 	public get extensionsPath(): string {
-		return path.join(paths.getAppDataPath(), "extensions");
+		return paths.getExtensionsDirectory();
 	}
 }
 

--- a/packages/vscode/src/fill/paths.ts
+++ b/packages/vscode/src/fill/paths.ts
@@ -4,6 +4,7 @@ class Paths {
 	private _appData: string | undefined;
 	private _defaultUserData: string | undefined;
 	private _socketPath: string | undefined;
+	private _extensionsDirectory: string | undefined;
 	private _builtInExtensionsDirectory: string | undefined;
 	private _workingDirectory: string | undefined;
 
@@ -31,6 +32,14 @@ class Paths {
 		return this._socketPath;
 	}
 
+	public get extensionsDirectory(): string {
+		if (!this._extensionsDirectory) {
+			throw new Error("trying to access extensions directory before it has been set");
+		}
+
+		return this._extensionsDirectory;
+	}
+
 	public get builtInExtensionsDirectory(): string {
 		if (!this._builtInExtensionsDirectory) {
 			throw new Error("trying to access builtin extensions directory before it has been set");
@@ -52,6 +61,7 @@ class Paths {
 		this._appData = data.dataDirectory;
 		this._defaultUserData = data.dataDirectory;
 		this._socketPath = sharedData.socketPath;
+		this._extensionsDirectory = data.extensionsDirectory;
 		this._builtInExtensionsDirectory = data.builtInExtensionsDirectory;
 		this._workingDirectory = data.workingDirectory;
 	}
@@ -61,5 +71,6 @@ export const _paths = new Paths();
 export const getAppDataPath = (): string => _paths.appData;
 export const getDefaultUserDataPath = (): string => _paths.defaultUserData;
 export const getWorkingDirectory = (): string => _paths.workingDirectory;
+export const getExtensionsDirectory = (): string => _paths.extensionsDirectory;
 export const getBuiltInExtensionsDirectory = (): string => _paths.builtInExtensionsDirectory;
 export const getSocketPath = (): string => _paths.socketPath;


### PR DESCRIPTION
Mirrors vscode CLI options `--user-data-dir` and `--extensions-dir`.

Allows inheriting local VS Code configuration (eg. `--user-data-dir ~/.config/User --extensions-dir ~/.vscode/extensions`).
