### PR TITLE
[GH-459] explicitly create a volume and set permission for project dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,14 @@ RUN adduser --gecos '' --disabled-password coder && \
 
 USER coder
 # We create first instead of just using WORKDIR as when WORKDIR creates, the user is root.
-RUN mkdir -p /home/coder/project
+RUN mkdir -p /home/coder/project && \
+    chmod g+rw /home/coder/project;
+
 WORKDIR /home/coder/project
+
+# This assures we have a volume mounted even if the user forgot to do bind mount.
+# XXX: Workaround for GH-459 and for OpenShift compatibility.
+VOLUME [ "/home/coder/project" ]
 
 COPY --from=0 /src/packages/server/cli-linux-x64 /usr/local/bin/code-server
 EXPOSE 8443


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

This ensures a emptydir volume if the user forgot to mount. This allows OpenShift compatibility and solves
Docker issues.

### Is there an open issue you can link to?

This fixes #459 and #469 partially

