### PR TITLE
change path for /home/coder/project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Try it out:
 ```bash
-docker run -it -p 127.0.0.1:8443:8443 -v "${PWD}:/home/coder/project" codercom/code-server:1.621 --allow-http --no-auth
+docker run -it -p 127.0.0.1:8443:8443 -v ~/coder:/home/coder/project codercom/code-server:1.621 --allow-http --no-auth
 ```
 
 - Code on your Chromebook, tablet, and laptop with a consistent dev environment.


### PR DESCRIPTION
The first time I ran coder I copied and pasted the command from the README, changed the IP, and immediately exposed my home directory to the network. Since it's the first example most people will run and it's encouraged to "try it out," I think mounting PWD to /home/coder/project is a bad recommendation. I was certainly surprised when I realized what I'd done, and I think it would make more sense for the README to make a better recommendation.