### PR TITLE
Add Docker CLI to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,13 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
-	openssl \
-	net-tools \
+	curl \
+	dumb-init \
 	git \
-	locales \
-	sudo \
-	dumb-init
+	locales \	
+	openssl \
+	net-tools \	
+	sudo
 
 RUN locale-gen en_US.UTF-8
 # We unfortunately cannot use update-locale because docker will not use the env variables


### PR DESCRIPTION

### Describe in detail the problem you had and how this PR fixes it

Run code-server in Docker, then browse and open a terminal. You have access to all the tools installed in the Docker image (e.g. git) but no app runtimes so you can't build or run anything. Adding the Docker CLI into the Docker image will let you mount the Docker engine from the host, and then you can do `docker build` and `docker run`.

### Is there an open issue you can link to?

No. See [this blog post](https://blog.sixeyed.com/adventures-in-docker-coding-on-a-remote-browser/) for usage.