### PR TITLE
Add GCP logging extender

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -9,5 +9,8 @@
 	"main": "out/main.js",
 	"types": "out/index.d.ts",
 	"author": "Coder",
-	"license": "MIT"
+	"license": "MIT",
+	"dependencies": {
+		"@google-cloud/logging": "^4.5.2"
+	}
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
 		"build": "tsc -p tsconfig.build.json && cp ./out/packages/logger/src/* ./out && rm -rf out/packages && ../../node_modules/.bin/webpack --config ./webpack.config.js",
 		"postinstall": "if [ ! -d out ];then npm run build; fi"
 	},
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"main": "out/main.js",
 	"types": "out/index.d.ts",
 	"author": "Coder",

--- a/packages/logger/src/extender.test.ts
+++ b/packages/logger/src/extender.test.ts
@@ -1,0 +1,12 @@
+import { field, logger } from "./logger";
+import { createStackdriverExtender } from "./extender";
+
+describe("Extender", () => {
+	it("should add stackdriver extender", () => {
+		logger.extend(createStackdriverExtender("coder-dev-1", "logging-package-tests"));
+	});
+
+	it("should log", async () => {
+		logger.debug("Bananas!", field("frog", { hi: "wow" }));
+	});
+});

--- a/packages/logger/src/extender.ts
+++ b/packages/logger/src/extender.ts
@@ -1,0 +1,63 @@
+import * as gcl from "@google-cloud/logging";
+import { Extender, logger, field } from "./logger";
+
+export const createStackdriverExtender = (projectId: string, logId: string): Extender => {
+	enum GcpLogSeverity {
+		DEFAULT = 0,
+		DEBUG = 100,
+		INFO = 200,
+		NOTICE = 300,
+		WARNING = 400,
+		ERROR = 500,
+		CRITICAL = 600,
+		ALERT = 700,
+		EMERGENCY = 800,
+	}
+
+	const logging = new gcl.Logging({
+		autoRetry: true,
+		projectId,
+	});
+
+	const log = logging.log(logId);
+	const convertSeverity = (severity: "trace" | "info" | "warn" | "debug" | "error"): GcpLogSeverity => {
+		switch (severity) {
+			case "trace":
+			case "debug":
+				return GcpLogSeverity.DEBUG;
+			case "info":
+				return GcpLogSeverity.INFO;
+			case "error":
+				return GcpLogSeverity.ERROR;
+			case "warn":
+				return GcpLogSeverity.WARNING;
+		}
+	};
+
+	return (options): void => {
+		const severity = convertSeverity(options.type);
+		// tslint:disable-next-line:no-any
+		const metadata = {} as any;
+		if (options.fields) {
+			options.fields.forEach((f) => {
+				if (!f) {
+					return;
+				}
+				metadata[f.identifier] = f.value;
+			});
+		}
+
+		const entry = log.entry({
+			// tslint:disable-next-line:no-any
+			severity: severity as any,
+		}, {
+			...metadata,
+			message: options.message,
+		});
+
+		log.write(entry).catch((ex) => {
+			logger.named("GCP").error("Failed to log", field("error", ex));
+		});
+	};
+
+};

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -59,6 +59,8 @@ export const field = <T>(name: string, value: T): Field<T> => {
 	return new Field(name, value);
 };
 
+export type Extender = (msg: { section?: string, type: "trace" | "info" | "warn" | "debug" | "error", message: string, fields?: FieldArray, level: Level }) => void;
+
 /**
  * This formats & builds text for logging.
  * It should only be used to build one log item at a time since it stores the
@@ -221,6 +223,7 @@ export class Logger {
 		private _formatter: Formatter,
 		private readonly name?: string,
 		private readonly defaultFields?: FieldArray,
+		private readonly extenders: Extender[] = [],
 	) {
 		if (name) {
 			this.nameColor = this.hashStringToColor(name);
@@ -246,6 +249,10 @@ export class Logger {
 	 */
 	public mute(): void {
 		this.muted = true;
+	}
+
+	public extend(extender: Extender): void {
+		this.extenders.push(extender);
 	}
 
 	/**
@@ -328,7 +335,7 @@ export class Logger {
 	 * Each name is deterministically generated a color.
 	 */
 	public named(name: string, ...fields: FieldArray): Logger {
-		const l = new Logger(this._formatter, name, fields);
+		const l = new Logger(this._formatter, name, fields, this.extenders);
 		if (this.muted) {
 			l.mute();
 		}
@@ -393,6 +400,16 @@ export class Logger {
 			console.log(...this._formatter.flush());
 		}
 		// tslint:enable no-console
+
+		this.extenders.forEach((extender) => {
+			extender({
+				section: this.name,
+				fields: options.fields,
+				level: options.level,
+				message: options.message as string,
+				type: options.type,
+			});
+		});
 	}
 
 	/**

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -59,7 +59,13 @@ export const field = <T>(name: string, value: T): Field<T> => {
 	return new Field(name, value);
 };
 
-export type Extender = (msg: { section?: string, type: "trace" | "info" | "warn" | "debug" | "error", message: string, fields?: FieldArray, level: Level }) => void;
+export type Extender = (msg: {
+	message: string,
+	level: Level,
+	type: "trace" | "info" | "warn" | "debug" | "error",
+	fields?: FieldArray,
+	section?: string,
+}) => void;
 
 /**
  * This formats & builds text for logging.


### PR DESCRIPTION
Adds `logger.extend(<Extender>)` API along with GCP stackdriver extender.