### PR TITLE
Add flag to install an extension from the command line

### DIFF
--- a/packages/vscode/src/fill/environmentService.ts
+++ b/packages/vscode/src/fill/environmentService.ts
@@ -1,7 +1,9 @@
-import * as path from "path";
 import * as paths from "./paths";
 import * as environment from "vs/platform/environment/node/environmentService";
 
+/**
+ * Customize paths using data received from the initialization message.
+ */
 export class EnvironmentService extends environment.EnvironmentService {
 	public get sharedIPCHandle(): string {
 		return paths.getSocketPath() || super.sharedIPCHandle;

--- a/packages/vscode/webpack.bootstrap.config.js
+++ b/packages/vscode/webpack.bootstrap.config.js
@@ -60,7 +60,7 @@ module.exports = merge(
 				"native-keymap": path.join(vsFills, "native-keymap.ts"),
 				"native-watchdog": path.join(vsFills, "native-watchdog.ts"),
 				"vs/base/common/amd": path.resolve(vsFills, "amd.ts"),
-				"vs/base/node/paths": path.resolve(vsFills, "paths.ts"),
+				"vs/base/node/paths": path.join(vsFills, "paths.ts"),
 				"vs/platform/product/node/package": path.resolve(vsFills, "package.ts"),
 				"vs/platform/product/node/product": path.resolve(vsFills, "product.ts"),
 				"vs/base/node/zip": path.resolve(vsFills, "zip.ts"),

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -150,6 +150,14 @@ index 6fd8249..039d31a 100644
 @@ -223,0 +228,2 @@ async function handshake(configuration: ISharedProcessConfiguration): Promise<vo
 +
 +startup({ machineId: "1" });
+diff --git a/src/vs/code/node/cli.ts b/src/vs/code/node/cli.ts
+index 1f8b17a..2a875f9 100644
+--- a/src/vs/code/node/cli.ts
++++ b/src/vs/code/node/cli.ts
+@@ -43,0 +44,3 @@ export async function main(argv: string[]): Promise<any> {
++	const cli = await new Promise<IMainCli>((c, e) => require(['vs/code/node/cliProcessMain'], c, e));
++	await cli.main(args);
++	return; // Always just do this for now.
 diff --git a/src/vs/editor/browser/config/configuration.ts b/src/vs/editor/browser/config/configuration.ts
 index f97a692..0206957 100644
 --- a/src/vs/editor/browser/config/configuration.ts


### PR DESCRIPTION
Opted to just run VS Code's CLI with a small modification to ensure it always only does extension management. Not sure if this is the best way. We could directly import the file but then there were Typescript errors that I wasn't sure how to solve cleanly.

Also wasn't sure how to make Commander accept variadic options for an option. Maybe it's not possible?