### PR TITLE
Fix password sign in with service-worker

### DIFF
--- a/scripts/webpack.client.config.js
+++ b/scripts/webpack.client.config.js
@@ -71,9 +71,10 @@ module.exports = (options = {}) => merge(
       })
     ].concat(prod ? [
       new GenerateSW({
+        exclude: [/\.map$/, /^manifest.*\.js$/, /\.html$/],
         runtimeCaching: [
           {
-            urlPattern: new RegExp(".*"),
+            urlPattern: new RegExp("^(?!.*(html))"),
             handler: "StaleWhileRevalidate",
             options: {
               cacheName: "code-server",
@@ -87,7 +88,7 @@ module.exports = (options = {}) => merge(
           }
           // Network first caching is also possible.
           /*{
-        urlPattern: "",
+        urlPattern: new RegExp("^(?!.*(html))"),
         handler: "NetworkFirst",
         options: {
           networkTimeoutSeconds: 4,


### PR DESCRIPTION
## Issue
Fixes issue #510.

## Fix
Fixed by disabling caching for all `*.html` files in service worker definition for Workbox.

## Testing setup
- Chrome 75.0.3768.0
- macOS 10.14.4
- Docker 2.0.0.3. 
- installed PWA

Ran using `docker run -it -p 127.0.0.1:8443:8443 -v "$HOME/projects:/home/coder/projects" codercom/code-server --allow-http` then served with valid cert using `ngrok http 8443`.