### PR TITLE
Disable beforeUnload during app mode

### DIFF
--- a/packages/ide/src/client.ts
+++ b/packages/ide/src/client.ts
@@ -35,10 +35,14 @@ export abstract class IdeClient {
 
 		let appWindow: Window | undefined;
 
-		window.addEventListener("beforeunload", (e) => {
-			e.preventDefault(); // FireFox
-			e.returnValue = ""; // Chrome
-		});
+		if (!window.matchMedia("(display-mode: standalone)").matches) {
+			console.log("Not in app mode");
+			window.addEventListener("beforeunload", (e) => {
+				e.preventDefault(); // FireFox
+				e.returnValue = ""; // Chrome
+			});
+		}
+
 
 		window.addEventListener("message", (event) => {
 			if (event.data === "app") {


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
When code-server is running in app mode, the close window confirmation is annoying and unnecessary. This change prevents that behavior if in app mode.

### Is there an open issue you can link to?
fixes #574