### PR TITLE
Reduce `docker build context` size.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,18 @@
 Dockerfile
 # Docs
 doc/
+# Lib & dist
+lib/
+**/dist/
+**/out/
+**/node_modules/
+# Build binary
+packages/server/cli-*
+# Cache
+.cache
 # GitHub stuff
 .github
 .gitignore
 .travis.yml
 LICENSE
 README.md
-node_modules


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it
For local build.  
Change from 2.6g to 38m.
### Is there an open issue you can link to?

